### PR TITLE
Fix build for Windows

### DIFF
--- a/libpurple/protocols/jabber/mam.h
+++ b/libpurple/protocols/jabber/mam.h
@@ -46,7 +46,7 @@ typedef struct {
     list_t *queue;
     mam_item_t *current;
     char last_timestamp[32];
-    uint32_t count;
+    guint32 count;
 } mam_t;
 
 void jabber_mam_clear(mam_t *mam);


### PR DESCRIPTION
`uint32_t`is not present on Windows. Use the platform-independent Glib type `guint32` instead.
